### PR TITLE
Fix: Open notifications in new tab

### DIFF
--- a/Notifier for GitHub.safariextension/Info.plist
+++ b/Notifier for GitHub.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Sindre Sorhus</string>
 	<key>Builder Version</key>
-	<string>11601.5.17.1</string>
+	<string>11601.3.9</string>
 	<key>CFBundleDisplayName</key>
 	<string>Notifier for GitHub</string>
 	<key>CFBundleIdentifier</key>
@@ -42,7 +42,7 @@
 	<key>Description</key>
 	<string>Displays your GitHub notifications unread count</string>
 	<key>DeveloperIdentifier</key>
-	<string>7GFU92S89J</string>
+	<string>YG56YK5RN5</string>
 	<key>ExtensionInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>Permissions</key>

--- a/Notifier for GitHub.safariextension/Info.plist
+++ b/Notifier for GitHub.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Sindre Sorhus</string>
 	<key>Builder Version</key>
-	<string>11601.3.9</string>
+	<string>11601.5.17.1</string>
 	<key>CFBundleDisplayName</key>
 	<string>Notifier for GitHub</string>
 	<key>CFBundleIdentifier</key>
@@ -42,7 +42,7 @@
 	<key>Description</key>
 	<string>Displays your GitHub notifications unread count</string>
 	<key>DeveloperIdentifier</key>
-	<string>YG56YK5RN5</string>
+	<string>7GFU92S89J</string>
 	<key>ExtensionInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>Permissions</key>

--- a/Notifier for GitHub.safariextension/main.js
+++ b/Notifier for GitHub.safariextension/main.js
@@ -30,9 +30,9 @@
 			var win = safari.application.activeBrowserWindow;
 			var url = 'https://github.com/notifications';
 
-            var newTab = safari.application.activeBrowserWindow.openTab();
-            newTab.url = url;
-            newTab.activate();
+      var newTab = win.openTab();
+      newTab.url = url;
+      newTab.activate();
 		}
 	});
 

--- a/Notifier for GitHub.safariextension/main.js
+++ b/Notifier for GitHub.safariextension/main.js
@@ -30,11 +30,9 @@
 			var win = safari.application.activeBrowserWindow;
 			var url = 'https://github.com/notifications';
 
-			if (win.activeTab.url) {
-				win.openTab().url = url;
-			} else {
-				win.activeTab.url = url;
-			}
+            var newTab = safari.application.activeBrowserWindow.openTab();
+            newTab.url = url;
+            newTab.activate();
 		}
 	});
 


### PR DESCRIPTION
This will always open notification page in a new foreground tab.
